### PR TITLE
Refine email validation for analyze endpoint

### DIFF
--- a/app/api/controllers/analyze.py
+++ b/app/api/controllers/analyze.py
@@ -1,18 +1,17 @@
-from fastapi import APIRouter, UploadFile, File, Query, HTTPException
+from fastapi import APIRouter, UploadFile, File, Query
+from pydantic import EmailStr
 from app.services.analyze_service import AnalyzeService
 
 router = APIRouter()
 
 @router.post("/analyze_document")
 async def analyze_document(
-    email: str = Query(..., description="E-mail do usuário para identificação"),
+    email: EmailStr = Query(..., description="E-mail do usuário para identificação"),
     file: UploadFile = File(...)
 ):
     """Recebe um PDF, valida o e-mail e retorna os metadados extraídos."""
 
-    # # 🔍 **Validação do E-mail**
-    # if not is_valid_email(email):
-    #     raise HTTPException(status_code=400, detail="E-mail inválido")
+
 
     # 🛠 **Processamento do Documento**
     extracted_data = await AnalyzeService.process_document(file, email)


### PR DESCRIPTION
## Summary
- use `EmailStr` type for the `email` parameter in `analyze.py`
- remove unused email validation comment

## Testing
- `python -m py_compile app/api/controllers/analyze.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e4047ba083318df1342293b397fa