### PR TITLE
Fix context block detection regex

### DIFF
--- a/app/parsers/question_parser/detect_context_blocks.py
+++ b/app/parsers/question_parser/detect_context_blocks.py
@@ -12,10 +12,12 @@ def detect_context_blocks(text: str) -> list[dict]:
     start_patterns = [
         r"Leia o texto a seguir",
         r"Analise o texto a seguir",
-        r"Observe (a|o) (imagem|gráfico|tabela)",
-        r"Texto \d?:?",
+        r"Leia este texto",
+        r"Analise a imagem",
+        r"Observe (a|o) (imagem|gr[áa]fico|tabela)",
+        r"^Texto\s*\d*[:.-]?$",
         r"Baseando-se no texto",
-        r"Com base no texto"
+        r"Com base no texto",
     ]
     start_regex = re.compile("|".join(start_patterns), re.IGNORECASE)
 


### PR DESCRIPTION
## Summary
- fix `detect_context_blocks` so that generic pattern `Texto \d` does not match unrelated lines
- include patterns for `Leia este texto` and `Analise a imagem`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858394ee7e4833180f3568dfa37c4aa