### PR TITLE
Corrigir lógica de extração de PDF

### DIFF
--- a/app/parsers/question_parser/base.py
+++ b/app/parsers/question_parser/base.py
@@ -9,6 +9,9 @@ class QuestionParser:
         questions = detect_questions(text)
         linked_questions = match_context_to_questions(questions, context_blocks, text)
 
+        for block in context_blocks:
+            block.pop("raw_content", None)
+
         return {
             "context_blocks": context_blocks,
             "questions": linked_questions

--- a/app/parsers/question_parser/detect_context_blocks.py
+++ b/app/parsers/question_parser/detect_context_blocks.py
@@ -1,11 +1,45 @@
 import re
 
+
+def _parse_block(block_id: int, content: str, has_image: bool) -> dict:
+    """Converte o texto cru do bloco em uma estrutura mais detalhada."""
+    lines = [l.strip() for l in content.splitlines() if l.strip()]
+
+    if has_image:
+        enunciado = lines[0] if lines else ""
+        return {
+            "id": block_id,
+            "type": "image",
+            "source": "",
+            "enunciado": enunciado,
+            "content": "",
+            "_comment": "Adicionar a imagem em base64 aqui na propriedade 'content'",
+            "hasImage": True,
+            "raw_content": content,
+        }
+
+    source = lines[0] if lines else ""
+    enunciado = lines[1] if len(lines) > 1 else ""
+    title = lines[-1] if len(lines) > 2 else ""
+    paragraph_lines = lines[2:-1] if len(lines) > 3 else []
+
+    return {
+        "id": block_id,
+        "type": "text",
+        "source": source,
+        "enunciado": enunciado,
+        "paragraphs": [{"text": p} for p in paragraph_lines],
+        "title": title,
+        "hasImage": False,
+        "raw_content": content,
+    }
+
 def detect_context_blocks(text: str) -> list[dict]:
     """
     Detecta blocos de leitura (textos base) antes das questões.
     Retorna uma lista com: id, content, hasImage.
     """
-    blocks = []
+    blocks: list[dict] = []
     block_id = 1
 
     # Marcadores típicos de introdução de texto
@@ -31,11 +65,13 @@ def detect_context_blocks(text: str) -> list[dict]:
     for line in lines:
         if start_regex.search(line):
             if inside_block and current_block:
-                blocks.append({
-                    "id": block_id,
-                    "content": "\n".join(current_block).strip(),
-                    "hasImage": any("imagem" in l.lower() for l in current_block)
-                })
+                blocks.append(
+                    _parse_block(
+                        block_id,
+                        "\n".join(current_block).strip(),
+                        any("imagem" in l.lower() for l in current_block),
+                    )
+                )
                 block_id += 1
                 current_block = []
             inside_block = True
@@ -44,11 +80,13 @@ def detect_context_blocks(text: str) -> list[dict]:
 
         if question_regex.search(line):
             if inside_block and current_block:
-                blocks.append({
-                    "id": block_id,
-                    "content": "\n".join(current_block).strip(),
-                    "hasImage": any("imagem" in l.lower() for l in current_block)
-                })
+                blocks.append(
+                    _parse_block(
+                        block_id,
+                        "\n".join(current_block).strip(),
+                        any("imagem" in l.lower() for l in current_block),
+                    )
+                )
                 block_id += 1
                 current_block = []
                 inside_block = False
@@ -59,10 +97,12 @@ def detect_context_blocks(text: str) -> list[dict]:
 
     # Último bloco (caso não encerrado por questão)
     if inside_block and current_block:
-        blocks.append({
-            "id": block_id,
-            "content": "\n".join(current_block).strip(),
-            "hasImage": any("imagem" in l.lower() for l in current_block)
-        })
+        blocks.append(
+            _parse_block(
+                block_id,
+                "\n".join(current_block).strip(),
+                any("imagem" in l.lower() for l in current_block),
+            )
+        )
 
     return blocks

--- a/app/parsers/question_parser/detect_questions.py
+++ b/app/parsers/question_parser/detect_questions.py
@@ -26,13 +26,21 @@ def detect_questions(text: str) -> list[dict]:
         # ✅ Usa a função atualizada que retorna question_text, alternatives e último índice
         question_text, alternatives, _ = extract_alternatives_from_lines(lines)
 
+        alt_list = []
+        for alt in alternatives:
+            match_alt = re.match(r"^\(?([A-E])\)?\s*(.*)", alt.strip())
+            if match_alt:
+                alt_list.append({"letter": match_alt.group(1), "text": match_alt.group(2).strip()})
+            else:
+                alt_list.append({"letter": "", "text": alt.strip()})
+
         # ✅ Detecta presença de imagem com base no texto da questão
         has_image = "imagem" in question_text.lower() or "figura" in question_text.lower()
 
         questions.append({
             "number": number,
             "question": question_text,
-            "alternatives": [alt.strip() for alt in alternatives],
+            "alternatives": alt_list,
             "hasImage": has_image,
             "context_id": None
         })

--- a/app/parsers/question_parser/extract_alternatives_from_lines.py
+++ b/app/parsers/question_parser/extract_alternatives_from_lines.py
@@ -10,7 +10,7 @@ def extract_alternatives_from_lines(lines: list[str], start_index: int = 0) -> t
     """
     alternatives = []
     current_alternative = ""
-    pattern = re.compile(r"^\([A-Z]\)")
+    pattern = re.compile(r"^\(?[A-E][\)\.\-]?", re.IGNORECASE)
 
     question_lines = []
     i = start_index

--- a/app/parsers/question_parser/match_context_to_questions.py
+++ b/app/parsers/question_parser/match_context_to_questions.py
@@ -18,7 +18,10 @@ def match_context_to_questions(
 
     # Localiza a posição dos contextos no texto
     context_positions = [
-        (ctx["id"], text.find(ctx["content"]))
+        (
+            ctx["id"],
+            text.find(ctx.get("raw_content", ctx.get("content", "")))
+        )
         for ctx in contexts
     ]
 


### PR DESCRIPTION
## Summary
- improve context block parsing with `_parse_block`
- generate structured alternatives with letter and text
- make alternative detection more robust
- associate questions and contexts using raw text
- clean helper fields before returning from `QuestionParser`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583e6b402c83318aeb09bbf393cf33